### PR TITLE
refactor: used server action for onboard form handling

### DIFF
--- a/apps/web/actions/onboard.ts
+++ b/apps/web/actions/onboard.ts
@@ -1,0 +1,52 @@
+"use server";
+import { ZOnboardFormSchema } from "@repo/types";
+import { usernameExists, addUsername } from "@repo/db";
+import { redirect } from "next/navigation";
+export interface IOnboardFormPrevState {
+  message: string;
+  error: unknown;
+  errorType?: string;
+}
+
+export async function OnboardUserAction(
+  prevState: IOnboardFormPrevState,
+  formData: FormData,
+) {
+  const id = formData.get("id");
+  const username = formData.get("username");
+
+  const parsedInput = ZOnboardFormSchema.safeParse({
+    username,
+    id,
+  });
+
+  if (!parsedInput.success) {
+    return {
+      message: "Validation error",
+      error: parsedInput.error.errors[0]?.message,
+      errorType: "EValidationError",
+    };
+  }
+
+  const existingusername = await usernameExists({
+    username: parsedInput.data.username,
+  });
+  if (existingusername) {
+    return {
+      message: "Username already taken",
+      error: "username is already taken, please try again.",
+      errorType: "EUserInputError",
+    };
+  }
+
+  await addUsername({
+    id: parsedInput.data.id,
+    username: parsedInput.data.username,
+  });
+
+  redirect("/proctected");
+  return {
+    message: "Successfully created username",
+    error: null,
+  };
+}

--- a/apps/web/actions/onboard.ts
+++ b/apps/web/actions/onboard.ts
@@ -1,7 +1,9 @@
 "use server";
 import { ZOnboardFormSchema } from "@repo/types";
-import { usernameExists, addUsername } from "@repo/db";
+import { usernameExists, addUsername, getUserByEmail } from "@repo/db";
 import { redirect } from "next/navigation";
+import { getServerSession } from "@repo/auth/server";
+import { authOptions } from "@repo/auth";
 export interface IOnboardFormPrevState {
   message: string;
   error: unknown;
@@ -12,12 +14,14 @@ export async function OnboardUserAction(
   prevState: IOnboardFormPrevState,
   formData: FormData,
 ) {
-  const id = formData.get("id");
+  // get id from db call here (So that it doesn't appear in payload)
+  const session = await getServerSession(authOptions);
+  const user = await getUserByEmail({ email: session?.user?.email! });
   const username = formData.get("username");
 
   const parsedInput = ZOnboardFormSchema.safeParse({
     username,
-    id,
+    id: user?.id,
   });
 
   if (!parsedInput.success) {

--- a/apps/web/app/onboard/page.tsx
+++ b/apps/web/app/onboard/page.tsx
@@ -27,7 +27,7 @@ export default async function Onboarduser() {
   // /onboard page will be rendered only if the user is a new user and doesn't have a username
   return (
     <div className="w-full h-[49.5rem] bg-gradient-to-br from-blue-100 via-yellow-50 to-green-100 flex justify-center items-center">
-      <OnboardForm id={user?.id as string} />
+      <OnboardForm />
     </div>
   );
 }

--- a/apps/web/components/onboard-form.tsx
+++ b/apps/web/components/onboard-form.tsx
@@ -14,7 +14,7 @@ import { SpinnerOutline } from "@repo/ui/components/utils/spinner";
 import { useFormState, useFormStatus } from "react-dom";
 import { IOnboardFormPrevState, OnboardUserAction } from "../actions/onboard";
 
-export const OnboardForm = ({ id }: { id: string }) => {
+export const OnboardForm = () => {
   const initState = {
     message: "",
     error: null,
@@ -27,20 +27,14 @@ export const OnboardForm = ({ id }: { id: string }) => {
       </CardHeader>
       <CardContent>
         <form action={formAction} className="space-y-8">
-          <OnboardFormFields id={id} state={state} />
+          <OnboardFormFields state={state} />
         </form>
       </CardContent>
     </Card>
   );
 };
 
-function OnboardFormFields({
-  id,
-  state,
-}: {
-  id: string;
-  state: IOnboardFormPrevState;
-}) {
+function OnboardFormFields({ state }: { state: IOnboardFormPrevState }) {
   const { pending } = useFormStatus();
   return (
     <>
@@ -51,7 +45,6 @@ function OnboardFormFields({
         </div>
         <fieldset disabled={pending}>
           <Input placeholder="JhonDoe" name="username" />
-          <Input defaultValue={id} name="id" className="hidden" />
           {state.errorType && state.errorType === "EValidationError" && (
             <div className="text-sm text-red-400 pt-2 px-1 -pb-2">
               <span>{state.error as string}</span>

--- a/apps/web/components/onboard-form.tsx
+++ b/apps/web/components/onboard-form.tsx
@@ -1,13 +1,5 @@
 "use client";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@repo/ui/components/ui/form";
+
 import { Input } from "@repo/ui/components/ui/input";
 import { Button } from "@repo/ui/components/ui/button";
 import {
@@ -18,84 +10,77 @@ import {
   CardHeader,
   CardTitle,
 } from "@ui/components/ui/card";
-import { useRouter } from "next/navigation";
 import { SpinnerOutline } from "@repo/ui/components/utils/spinner";
-import { addUsername, usernameExists } from "@repo/db";
-import { ZOnboardFormSchema } from "@repo/types";
-import { z, zodResolver, useForm } from "@repo/ui/lib/react-hook-forms";
-import { toast } from "sonner";
+import { useFormState, useFormStatus } from "react-dom";
+import { IOnboardFormPrevState, OnboardUserAction } from "../actions/onboard";
 
 export const OnboardForm = ({ id }: { id: string }) => {
-  const router = useRouter();
-  const form = useForm<z.infer<typeof ZOnboardFormSchema>>({
-    resolver: zodResolver(ZOnboardFormSchema),
-    defaultValues: {
-      username: "",
-    },
-  });
-
-  const onSubmit = async (values: z.infer<typeof ZOnboardFormSchema>) => {
-    // Shows loading state for better UX
-    await new Promise((resolve) => {
-      setTimeout(resolve, 1.5 * 1000);
-    });
-
-    const USERNAME_EXISTS = await usernameExists({ username: values.username });
-    if (USERNAME_EXISTS) {
-      form.reset();
-      return toast.error("username already exists. Please try again!");
-    }
-    await addUsername({
-      id,
-      username: values.username,
-    });
-    router.push("/proctected");
+  const initState = {
+    message: "",
+    error: null,
   };
+  const [state, formAction] = useFormState(OnboardUserAction, initState);
   return (
     <Card className="w-[23.5rem]">
-      <CardHeader className="p-4 text-center">
+      <CardHeader className="p-4 -mb-6 text-center">
         <CardTitle className="text-xl">Username</CardTitle>
       </CardHeader>
       <CardContent>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-            <FormField
-              control={form.control}
-              name="username"
-              disabled={form.formState.isSubmitting}
-              render={({ field }) => (
-                <FormItem className="-mb-2">
-                  <FormDescription className="pb-3">
-                    Create a unique username, 5-20 characters, using letters,
-                    numbers, or underscores.
-                  </FormDescription>
-                  <FormControl>
-                    <Input placeholder="JhonDoe" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            {form.formState.isSubmitting ? (
-              <div className="flex justify-center items-center">
-                <Button
-                  disabled={form.formState.isSubmitting}
-                  className="w-full flex justify-center items-center gap-1 px-8"
-                >
-                  <SpinnerOutline />
-                  <span>Submitting...</span>
-                </Button>
-              </div>
-            ) : (
-              <div className="flex justify-center items-center">
-                <Button type="submit" className="w-full">
-                  Submit
-                </Button>
-              </div>
-            )}
-          </form>
-        </Form>
+        <form action={formAction} className="space-y-8">
+          <OnboardFormFields id={id} state={state} />
+        </form>
       </CardContent>
     </Card>
   );
 };
+
+function OnboardFormFields({
+  id,
+  state,
+}: {
+  id: string;
+  state: IOnboardFormPrevState;
+}) {
+  const { pending } = useFormStatus();
+  return (
+    <>
+      <div className="-my-2">
+        <div className="pb-3 text-sm text-muted-foreground">
+          Create a unique username, 5-20 characters, using letters, numbers, or
+          underscores.
+        </div>
+        <fieldset disabled={pending}>
+          <Input placeholder="JhonDoe" name="username" />
+          <Input defaultValue={id} name="id" className="hidden" />
+          {state.errorType && state.errorType === "EValidationError" && (
+            <div className="text-sm text-red-400 pt-2 px-1 -pb-2">
+              <span>{state.error as string}</span>
+            </div>
+          )}
+          {state.errorType && state.errorType === "EUserInputError" && (
+            <div className="text-sm text-red-400 pt-1 px-1 -pb-2">
+              <span>{state.error as string}</span>
+            </div>
+          )}
+        </fieldset>
+      </div>
+
+      <div>
+        <Button
+          type="submit"
+          disabled={pending}
+          className="w-full flex justify-center items-center"
+        >
+          {pending ? (
+            <div className="flex justify-center items-center gap-1">
+              <SpinnerOutline />
+              <span>Submitting...</span>
+            </div>
+          ) : (
+            <span>Submit</span>
+          )}
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/packages/types/src/forms/index.ts
+++ b/packages/types/src/forms/index.ts
@@ -19,4 +19,5 @@ export const ZOnboardFormSchema = z.object({
           "Username should not contain any special characters expect underscore",
       },
     ),
+  id: z.string().min(0, { message: "User id is required" }),
 });


### PR DESCRIPTION
Fixes #7 

## Changes proposed
Used server actions for form handling instead of client-side handling

- [x] server-side input validation using zod
- [x] redirects to `/proctected` route after successful form submission
- [x] loading and error states in UI